### PR TITLE
Fix terrafrom with OCI errors

### DIFF
--- a/oci/README.md
+++ b/oci/README.md
@@ -4,10 +4,14 @@ Instructions to deploy vThunder on OCI:
 https://github.com/a10networks/a10-terraform.git
 
 2) In your cloned repository, go to the oci directory. Now edit the tfvars file to set values for all variables:
-~/oci/main/existing_infra/util/terraform.tfvars
+Check ../README.md first to know the difference between new_infra and existing_infra then go to corrsponding directory:
+ - main/new_infra/util/
+ - main/existing_infra/util/
 
 3) To spin-up an OCI instance(s), run the below script:
 ./a10-spin-oci-instance.sh
 
 4) To tear-down those OCI instance(s), run the below script:
 ./a10-tear-down-oci-instance.sh
+
+Suggested Terraform version: v0.15.0

--- a/oci/main/new_infra/util/terraform.tfvars
+++ b/oci/main/new_infra/util/terraform.tfvars
@@ -10,22 +10,26 @@ private_key_password = ""
 fingerprint          = ""
 
 #vThunder VM details
-vm_display_name              = "TF-vThunder"
 vThunder__image_ocid         = "ocid1.image.oc1..aaaaaaaanh6fkm63h7n2vhffmt47dxng2aptzs3vzy6m2utfak7idif32vta"
-vm_availability_domain       = ""
 vm_shape                     = "VM.Standard2.8"
 vm_creation_timeout          = "5m"
 vm_primary_vnic_display_name = "primary-vnic"
 vm_ssh_public_key_path       = ""
+vm_count                     = "1"
+vthunder_name                = ""
+
+#VCN
+vcn_name = ""
+vcn_cidrs =
+
+#Subnet CIDRs - Set 3 CIDRs for primary, client and server subnet
+subnet_cidr =
 
 #Secondary VNIC details - server
-server_vnic_private_ip   = "10.0.2.10"
 server_vnic_display_name = "server"
 server_vnic_index        = "1"
 
 #Secondary VNIC details - client
-client_vnic_private_ip   = "10.0.3.10"
 client_vnic_display_name = "client"
 client_vnic_index        = "2"
 
-app_display_name = "app"

--- a/oci/modules/infra/NIC/nic.tf
+++ b/oci/modules/infra/NIC/nic.tf
@@ -5,10 +5,10 @@ variable "app_display_name" {
 #variable "instance_id2" {
 #}
 
-variable "instance_list" {
-  type        = list(string)
-  description = "instance list"
-}
+#variable "instance_list" {
+#  type        = list(string)
+#  description = "instance list"
+#}
 
 variable "instance_id_active" {
   description = "instance id active"
@@ -122,7 +122,7 @@ data "oci_core_vnic" "test_vnic_server" {
 
 
 #Standby Vthuder NIC settings
-
+/*
 resource "oci_core_vnic_attachment" "client_vnic2" {
   #for_each = toset(var.instance_list)
   count = length(var.instance_list)
@@ -179,13 +179,13 @@ data "oci_core_vnic" "vt2_vnic_server" {
   #for_each = toset(oci_core_vnic_attachment.server_vnic2.*.vnic_id)
   vnic_id = element(oci_core_vnic_attachment.server_vnic2.*.vnic_id, tonumber(count.index))
 }
-
+*/
 output "vnic_id" { value = oci_core_vnic_attachment.client_vnic.vnic_id }
 output "client_vnic_private_ip" { value = data.oci_core_vnic.test_vnic_client.private_ip_address }
-output "client_vnic_private_ip2_list" { value = data.oci_core_vnic.vt2_vnic_client.*.private_ip_address }
+#output "client_vnic_private_ip2_list" { value = data.oci_core_vnic.vt2_vnic_client.*.private_ip_address }
 output "client_vip_private_ip" { value = oci_core_private_ip.client_vnic_private_ip.ip_address } #secondary vip private IP
 output "server_nic_private_ip" { value = data.oci_core_vnic.test_vnic_server.private_ip_address }
-output "server_nic_private_ip2_list" { value = data.oci_core_vnic.vt2_vnic_server.*.private_ip_address }
+#output "server_nic_private_ip2_list" { value = data.oci_core_vnic.vt2_vnic_server.*.private_ip_address }
 
 #floating IP
 output "floating_client_private_ip" { value = oci_core_private_ip.floating_client_private_ip.ip_address }

--- a/oci/modules/infra/compute/compute.tf
+++ b/oci/modules/infra/compute/compute.tf
@@ -37,6 +37,11 @@ variable "count_vm" {
   default = "1"
 }
 
+variable "vthunder_name" {
+  description = "name of new vThunder"
+  default = "vm"
+}
+
 data "oci_core_images" "vThuder_image" {
   compartment_id = var.compartment_id
 }
@@ -49,7 +54,7 @@ resource "oci_core_instance" "vthunder_vm" {
   count          = var.count_vm
   compartment_id = var.compartment_id
 
-  display_name = "vthunder-vm-${count.index + 1}"
+  display_name = "vthunder-${var.vthunder_name}-${count.index + 1}"
 
   availability_domain = element(data.oci_identity_availability_domains.compartment_availability_domains.availability_domains, random_integer.availability_domain_id.result + count.index).name
 

--- a/oci/modules/infra/vcn/vcn.tf
+++ b/oci/modules/infra/vcn/vcn.tf
@@ -3,14 +3,19 @@ variable "compartment_id" {
   description = "Compartment OCID"
 }
 
-variable "vcn_cidr" {
+variable "vcn_name" {
+  description = "VCN Name"
+  default = "a10-vcn"
+}
+
+variable "vcn_cidrs" {
   description = "VCN CIDR"
 }
 
 resource "oci_core_virtual_network" "a10_vcn" {
   compartment_id = var.compartment_id
-  display_name   = "a10-vcn"
-  cidr_block     = var.vcn_cidr
+  display_name   = "${var.vcn_name}"
+  cidr_blocks     = var.vcn_cidrs
   dns_label      = "a10vcn"
 }
 


### PR DESCRIPTION
- Test the config with Terraform version: v0.15.0, OCI provider version: 4.24.0.
   Terraform version is recorded in README.md and OCI version is specified in oci-stack.tf
- Fix some Terraform errors and remove unused variables.
- Export new variables in terraform.tfvars so user can change vTH and VCN names.